### PR TITLE
set iframe height based on the height of its content

### DIFF
--- a/client/audio.coffee
+++ b/client/audio.coffee
@@ -20,8 +20,9 @@ parse = (text='') ->
 embed = ({key}) ->
   """
     <iframe
+      onload="this.height=this.contentWindow.document.body.clientHeight + 5 + 'px'"
       srcdoc='<audio src="#{key}" preload="none" controls style="width: 100%;"><a href="#{key}">download audio</a></audio>'
-      width="100%" frameborder=0 seamless scrolling="no" height="40px">
+      width="100%" frameborder=0 seamless scrolling="no">
     </iframe>
   """
 


### PR DESCRIPTION
add an onload script to set the height of the iframe based on the size of the contents.

without specifying a height the iframe will be 150px high. As the size of the audio player varies between browser we need to look into the iframe and use height of its body to set the height.